### PR TITLE
Fixed using curl to fetch key

### DIFF
--- a/varnish/repo.sls
+++ b/varnish/repo.sls
@@ -1,34 +1,17 @@
 {% from "varnish/map.jinja" import varnish with context -%}
 
-
 include:
   - varnish
 
-
 {% if salt['grains.get']('os_family') == 'Debian' -%}
-varnish_repo_curl:
-  pkg.installed:
-    - name: curl
-
-
 varnish_repo:
-  # Import varnish repo GPG key
-  cmd.run:
-    - name: /usr/bin/curl http://repo.varnish-cache.org/{{ salt['grains.get']('os')|lower }}/GPG-key.txt | sudo apt-key add -
-    - unless: /usr/bin/apt-key adv --list-key C4DEFFEB
-    - require:
-      - pkg: varnish_repo_curl
-# NOTE: pkgrepo state module requires "require_in" in order to play nice with
-# the pkg state module.
   pkgrepo.managed:
     - name: deb http://repo.varnish-cache.org/{{ salt['grains.get']('os')|lower }}/ {{ salt['grains.get']('oscodename')}} {{ varnish.repo.components | join(' ') }}
     - file: /etc/apt/sources.list.d/varnish.list
-    - require:
-      - cmd: varnish_repo
+    - keyid: C4DEFFEB
+    - keyserver: keyserver.ubuntu.com
     - require_in:
       - pkg: varnish
-
-
 {% elif salt['grains.get']('os_family') == 'RedHat' -%}
   {% for component in varnish.repo.components %}
 varnish_repo_{{ component }}:


### PR DESCRIPTION
There's no need to use curl to try to fetch the key from a remote repo, when salt can do it itself.

The key was recently moved by the varnish team.