### PR TITLE
- allow configurable vcl file on daemon start

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -12,6 +12,9 @@ varnish:
   # Listen address:port
   listen: ':80'
 
+  # specify which vcl to load on service start. defaults to default.vcl
+  default_vcl: mycustom.vcl
+
   # List of storage backends
   storages:
     - 'main=malloc,512m'

--- a/varnish/files/default/etc/default/varnish.jinja
+++ b/varnish/files/default/etc/default/varnish.jinja
@@ -8,7 +8,7 @@ NPROCS="unlimited"
 RELOAD_VCL=1
 DAEMON_OPTS="-a {{ settings.get('listen', ':6081')}} \
              -T localhost:6082 \
-             -f /etc/varnish/default.vcl \
+             -f /etc/varnish/{{ settings.get('default_vcl', 'default.vcl') }} \
              -S /etc/varnish/secret \
 {%- for storage in settings.get('storages', ['malloc,256M']) %}
              -s {{ storage }} \


### PR DESCRIPTION
- add info to pillar.example

regarding https://github.com/saltstack-formulas/varnish-formula/issues/9.
